### PR TITLE
Don't send new user email when user is confirming email address change

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -5,7 +5,13 @@ module Users
 
       raise "There is an open invitation for this user: #{resource.email}" if resource.needs_accept_invite?
 
-      resource.notify_new_user_signed_up if resource.errors.empty?
+      resource.notify_new_user_signed_up if resource.errors.empty? && !confirming_email_change?
     end
+
+    private
+
+      def confirming_email_change?
+        resource.unconfirmed_email_previously_changed?
+      end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -110,4 +110,21 @@ describe 'Users' do
       expect(page).to have_content('The entered token is invalid')
     end
   end
+
+  describe 'edit user registration' do
+    before do
+      login_as admin, scope: :user
+      visit edit_user_registration_path
+    end
+
+    it "can change user's own email address" do
+      visit edit_user_registration_path
+
+      fill_in 'user_email', with: "new_#{admin.email}"
+      fill_in 'Current Password', with: password
+      click_button 'Save'
+
+      expect(page).to have_content 'You updated your account successfully, but we need to verify your new email address.'
+    end
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -124,7 +124,7 @@ describe 'Users' do
       fill_in 'Current Password', with: password
       click_button 'Save'
 
-      expect(page).to have_content 'You updated your account successfully, but we need to verify your new email address.'
+      expect(page).to have_content 'You updated your account successfully, but we need to verify your new email address'
     end
   end
 end


### PR DESCRIPTION
Task 79
